### PR TITLE
fixed server path route not being served properly

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     port: 3000,
     open: true,
     proxy: {
-      '/api': {
+      '/graphql': {
         target: 'http://localhost:3001',
         secure: false,
         changeOrigin: true


### PR DESCRIPTION
fixed issue with /graphql path not being loaded properly; the proxy was set to API in the vite.config file, changed it to /grapql